### PR TITLE
Different duration for day/night phases

### DIFF
--- a/godfather/cogs/mafia/mafia.py
+++ b/godfather/cogs/mafia/mafia.py
@@ -151,7 +151,11 @@ class Mafia(commands.Cog):
         Shows when the current day/night ends.
         """
         game = self.bot.games[ctx.guild.id]
-        await ctx.send(f'🕰️ The current phase ends {from_now(game.phase_end_at)}')
+        if game.phase == Phase.DAY:
+            phase_str = 'day'
+        else:
+            phase_str = 'night'
+        await ctx.send(f'🕰️ The current {phase_str} ends {from_now(game.phase_end_at)}')
 
     @commands.command()
     @commands.cooldown(1, 5.0, commands.BucketType.channel)

--- a/godfather/game/game.py
+++ b/godfather/game/game.py
@@ -15,7 +15,8 @@ from .player import Player
 
 
 default_game_config = {
-    'phase_duration': 5 * 60  # In seconds
+    'day_duration': 5 * 60,  # In seconds
+    'night_duration': 2 * 60  # In seconds
 }
 
 
@@ -120,7 +121,17 @@ class Game:
         return (False, None, None)
 
     async def increment_phase(self):
-        phase_t = round(self.config['phase_duration'] / 60, 1)
+        # If it is day, `phase_t` should be equal to night_duration and vice versa.
+        # `phase_duration` is used at the end of the function.
+        # `phase_t` is used in day/night starting messages.
+        if self.phase == Phase.DAY:
+            phase_duration = self.config['night_duration']
+            phase_t = round(phase_duration / 60, 1)
+        else:
+            # Set it to day duration for all other phases.
+            # Note that it should almost always be `Phase.NIGHT`.
+            phase_duration = self.config['day_duration']
+            phase_t = round(phase_duration / 60, 1)
 
         # night loop is the same as the pregame loop
         if self.cycle == 0 or self.phase == Phase.NIGHT:
@@ -169,7 +180,7 @@ class Game:
             self.phase = Phase.NIGHT
 
         self.phase_end_at = datetime.now() \
-            + timedelta(seconds=self.config['phase_duration'])
+            + timedelta(seconds=phase_duration)
 
     # lynch a player
     async def lynch(self, target: Player):

--- a/godfather/game/game_config.py
+++ b/godfather/game/game_config.py
@@ -4,8 +4,11 @@ from godfather.utils.utils import convert_code_syntax_to_formal
 
 
 designated_messages = {
-    'phase_duration': (
-        lambda k, val: f'Phases will now last {round(val / 60, 1)} minutes.'
+    'day_duration': (
+        lambda k, val: f'Days will now last {round(val / 60, 1)} minutes.'
+    ),
+    'night_duration': (
+        lambda k, val: f'Nights will now last {round(val / 60, 1)} minutes.'
     )
 }
 
@@ -58,7 +61,7 @@ class GameConfig(dict):
 
     async def configure_setting(self, key, value):
         # Checks & overrides  NOTE: Separate from func??
-        if key == 'phase_duration':
+        if key == 'day_duration' or key == 'night_duration':
             if await self.check_phase_duration(value) is False:
                 return
             value = int(value)  # Convert to int after check


### PR DESCRIPTION
Day and night duration are now different. By default, days last 5 minutes and nights last 2 minutes. It can be configured by changing `day_duration` and `night_duration` respectively.

Additionally, it now displays the phase name in the output of `remaining` command.