### PR TITLE
Fix typo in Vigilante role description

### DIFF
--- a/src/assets/roledocs.json
+++ b/src/assets/roledocs.json
@@ -165,7 +165,7 @@
             "",
             "- Win Condition: lynch every criminal and evildoer",
             "",
-            "+ Abilities: take justics in your own hand and shoot someone at night.",
+            "+ Abilities: take justice in your own hand and shoot someone at night.",
             "+ You can only choose to shoot 3 times in a game.",
             "+ If you shoot another town member, you will commit suicide over the guilt of killing your own member next night."
         ]


### PR DESCRIPTION
Change `justics` to `justice`